### PR TITLE
[WIP] Introce SearchProcessor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,11 @@
     "require": {
         "php": ">=5.3.3",
         "rollerworks/search": "~1.0@dev",
+        "rollerworks/uri-encoder": "~1.0",
+        "rollerworks/exception-parser": "~1.0",
         "symfony/framework-bundle": "~2.1",
-        "symfony/finder": "~2.1"
+        "symfony/finder": "~2.1",
+        "symfony/form": "~2.1"
     },
     "require-dev": {
         "doctrine/orm": "~2.4",

--- a/src/Rollerworks/Bundle/SearchBundle/ExceptionParser/QueryExceptionParser.php
+++ b/src/Rollerworks/Bundle/SearchBundle/ExceptionParser/QueryExceptionParser.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of the RollerworksSearchBundle package.
+ *
+ * (c) 2014 Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\ExceptionParser;
+
+use Rollerworks\Component\ExceptionParser\ExceptionParserInterface;
+use Rollerworks\Component\Search\Input\FilterQuery\QueryException;
+
+class QueryExceptionParser implements ExceptionParserInterface
+{
+    public function accepts(\Exception $exception)
+    {
+        return $exception instanceof QueryException;
+    }
+
+    public function parseException(\Exception $exception)
+    {
+        if (preg_match('/^\[Syntax Error\] line (?P<line>\d+), col (?P<column>\d+): Error: Expected \'(?P<expected>[^\']+)\', got (?P<got>\'[^\']+\'|end of string\.)$/i', $exception->getMessage(), $matches)) {
+            return array(
+                'message' => 'rollerworks_search.syntax_error_got',
+                'line' => $matches['line'],
+                'column' => $matches['column'],
+                'expected' => $matches['expected'],
+                'got' => $matches['got'],
+                'unexpected_end' => 'rollerworks_search.end_of_string' === $matches['got'],
+            );
+        }
+
+        if (preg_match('/^\[Syntax Error\] line (?P<line>\d+), col (?P<column>\d+): Error: Unexpected (?P<unexpected>\'[^\']+\'|end of string\.)$/i', $exception->getMessage(), $matches)) {
+            return array(
+                'message' => 'rollerworks_search.syntax_error',
+                'line' => $matches['line'],
+                'column' => $matches['column'],
+                'unexpected' => $matches['unexpected'],
+                'unexpected_end' => 'rollerworks_search.end_of_string' === $matches['unexpected'],
+            );
+        }
+
+        return array(
+            'message' => $exception->getMessage(),
+            'line' => 0,
+            'column' => 0,
+            'unexpected_end' => false,
+        );
+    }
+}

--- a/src/Rollerworks/Bundle/SearchBundle/ExceptionParser/SearchFieldRequiredExceptionParser.php
+++ b/src/Rollerworks/Bundle/SearchBundle/ExceptionParser/SearchFieldRequiredExceptionParser.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of the RollerworksSearchBundle package.
+ *
+ * (c) 2014 Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\ExceptionParser;
+
+use Rollerworks\Component\ExceptionParser\ExceptionParserInterface;
+use Rollerworks\Component\Search\Exception\FieldRequiredException;
+
+class SearchFieldRequiredExceptionParser implements ExceptionParserInterface
+{
+    public function accepts(\Exception $exception)
+    {
+        return $exception instanceof FieldRequiredException;
+    }
+
+    public function parseException(\Exception $exception)
+    {
+        /** @var FieldRequiredException $exception */
+
+        return array(
+            'message' => 'Field "{{ field }}" is required but is missing in group {{ group }} at nesting level {{ nesting }}.',
+            'field' => $exception->getFieldName(),
+            'group' => $exception->getGroupIdx(),
+            'nesting' => $exception->getNestingLevel(),
+        );
+    }
+}

--- a/src/Rollerworks/Bundle/SearchBundle/ExceptionParser/SearchGroupsNestingExceptionParser.php
+++ b/src/Rollerworks/Bundle/SearchBundle/ExceptionParser/SearchGroupsNestingExceptionParser.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of the RollerworksSearchBundle package.
+ *
+ * (c) 2014 Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\ExceptionParser;
+
+use Rollerworks\Component\ExceptionParser\ExceptionParserInterface;
+use Rollerworks\Component\Search\Exception\GroupsNestingException;
+
+class SearchGroupsNestingExceptionParser implements ExceptionParserInterface
+{
+    public function accepts(\Exception $exception)
+    {
+        return $exception instanceof GroupsNestingException;
+    }
+
+    public function parseException(\Exception $exception)
+    {
+        /** @var GroupsNestingException $exception */
+
+        return array(
+            'message' => 'Group {{ group }} at nesting level {{ nesting }} exceeds maximum nesting level of {{ max }}.',
+            'group' => $exception->getGroupIdx(),
+            'nesting' => $exception->getNestingLevel(),
+            'max' => $exception->getMaxNesting(),
+        );
+    }
+}

--- a/src/Rollerworks/Bundle/SearchBundle/ExceptionParser/SearchGroupsOverflowExceptionParser.php
+++ b/src/Rollerworks/Bundle/SearchBundle/ExceptionParser/SearchGroupsOverflowExceptionParser.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of the RollerworksSearchBundle package.
+ *
+ * (c) 2014 Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\ExceptionParser;
+
+use Rollerworks\Component\ExceptionParser\ExceptionParserInterface;
+use Rollerworks\Component\Search\Exception\GroupsOverflowException;
+
+class SearchGroupsOverflowExceptionParser implements ExceptionParserInterface
+{
+    public function accepts(\Exception $exception)
+    {
+        return $exception instanceof GroupsOverflowException;
+    }
+
+    public function parseException(\Exception $exception)
+    {
+        /** @var GroupsOverflowException $exception */
+
+        return array(
+            'message' => 'Group {{ group }} at nesting level %d exceeds maximum number of groups, maximum: %d, total of groups: %d.',
+            'group' => $exception->getGroupIdx(),
+            'nesting' => $exception->getNestingLevel(),
+            'max' => $exception->getMax(),
+            'count' => $exception->getCount(),
+        );
+    }
+}

--- a/src/Rollerworks/Bundle/SearchBundle/ExceptionParser/SearchUnknownFieldExceptionParser.php
+++ b/src/Rollerworks/Bundle/SearchBundle/ExceptionParser/SearchUnknownFieldExceptionParser.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the RollerworksSearchBundle package.
+ *
+ * (c) 2014 Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\ExceptionParser;
+
+use Rollerworks\Component\ExceptionParser\ExceptionParserInterface;
+use Rollerworks\Component\Search\Exception\UnknownFieldException;
+
+class SearchUnknownFieldExceptionParser implements ExceptionParserInterface
+{
+    public function accepts(\Exception $exception)
+    {
+        return $exception instanceof UnknownFieldException;
+    }
+
+    public function parseException(\Exception $exception)
+    {
+        /** @var UnknownFieldException $exception */
+
+        return array(
+            'message' => 'Field "{{ field }}" is not registered in the FieldSet or available as alias.',
+            'field' => $exception->getFieldName(),
+        );
+    }
+}

--- a/src/Rollerworks/Bundle/SearchBundle/ExceptionParser/SearchUnsupportedValueTypeExceptionParser.php
+++ b/src/Rollerworks/Bundle/SearchBundle/ExceptionParser/SearchUnsupportedValueTypeExceptionParser.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the RollerworksSearchBundle package.
+ *
+ * (c) 2014 Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\ExceptionParser;
+
+use Rollerworks\Component\ExceptionParser\ExceptionParserInterface;
+use Rollerworks\Component\Search\Exception\UnsupportedValueTypeException;
+
+class SearchUnsupportedValueTypeExceptionParser implements ExceptionParserInterface
+{
+    public function accepts(\Exception $exception)
+    {
+        return $exception instanceof UnsupportedValueTypeException;
+    }
+
+    public function parseException(\Exception $exception)
+    {
+        /** @var UnsupportedValueTypeException $exception */
+
+        return array(
+            'message' => 'Field "{{ field }}" does not accept '.$exception->getValueType().' values.',
+            'field' => $exception->getFieldName(),
+        );
+    }
+}

--- a/src/Rollerworks/Bundle/SearchBundle/ExceptionParser/SearchValuesOverflowExceptionParser.php
+++ b/src/Rollerworks/Bundle/SearchBundle/ExceptionParser/SearchValuesOverflowExceptionParser.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of the RollerworksSearchBundle package.
+ *
+ * (c) 2014 Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\ExceptionParser;
+
+use Rollerworks\Component\ExceptionParser\ExceptionParserInterface;
+use Rollerworks\Component\Search\Exception\ValuesOverflowException;
+
+class SearchValuesOverflowExceptionParser implements ExceptionParserInterface
+{
+    public function accepts(\Exception $exception)
+    {
+        return $exception instanceof ValuesOverflowException;
+    }
+
+    public function parseException(\Exception $exception)
+    {
+        /** @var ValuesOverflowException $exception */
+
+        return array(
+            'message' => 'Field {{ field }} in group {{ group }} at nesting level {{ nesting }} exceeds the maximum number values per group, maximum: {{ max }}, total of values: {{ count }}.',
+            'field' => $exception->getFieldName(),
+            'group' => $exception->getGroupIdx(),
+            'nesting' => $exception->getNestingLevel(),
+            'max' => $exception->getMax(),
+            'count' => $exception->getCount(),
+        );
+    }
+}

--- a/src/Rollerworks/Bundle/SearchBundle/Form/Type/SearchFormType.php
+++ b/src/Rollerworks/Bundle/SearchBundle/Form/Type/SearchFormType.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of the RollerworksSearchBundle package.
+ *
+ * (c) 2014 Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class SearchFormType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('condition', 'textarea', array('data' => $options['condition']))
+            ->add('format', 'hidden', array('data' => $options['format']))
+            ->add('submit', 'submit')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver
+            ->setRequired(array('format', 'condition'))
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'rollerworks_search';
+    }
+}

--- a/src/Rollerworks/Bundle/SearchBundle/Processor/AbstractSearchProcessor.php
+++ b/src/Rollerworks/Bundle/SearchBundle/Processor/AbstractSearchProcessor.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * This file is part of the RollerworksSearchBundle package.
+ *
+ * (c) 2014 Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\Processor;
+
+use Rollerworks\Component\Search\FieldSet;
+use Rollerworks\Component\Search\SearchConditionInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * AbstractCacheSearchProcessor provides the basic logic for all processors.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+abstract class AbstractSearchProcessor implements SearchProcessorInterface
+{
+    /**
+     * @var Request
+     */
+    protected $request;
+
+    /**
+     * @var SearchConditionInterface
+     */
+    protected $searchCondition;
+
+    /**
+     * @var string
+     */
+    protected $filterCode = '';
+
+    /**
+     * @var string
+     */
+    protected $uriPrefix;
+
+    /**
+     * @var FieldSet
+     */
+    protected $fieldSet;
+
+    /**
+     * @var array
+     */
+    protected $errors = array();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilterCode()
+    {
+        return $this->filterCode;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSearchCondition()
+    {
+        return $this->searchCondition;
+    }
+
+    /**
+     * Returns whether the processed result is valid.
+     *
+     * @return bool
+     */
+    public function isValid()
+    {
+        if (count($this->errors) > 0) {
+            return false;
+        }
+
+        return !($this->searchCondition && $this->searchCondition->getValuesGroup()->hasErrors());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrors()
+    {
+        return $this->errors;
+    }
+
+    /**
+     * Gets a Request object value from the request.
+     *
+     * @param string          $name      Name of the parameter
+     * @param string          $default   Default value to use when value is missing or invalid
+     * @param bool            $query     Get from the instead of the POST
+     * @param callable|string $validator Callback to validate the value, default is string
+     *
+     * @return mixed|string
+     */
+    protected function getRequestParam($name, $default = '', $query = true, $validator = 'is_string')
+    {
+        $params = $query ? $this->request->query : $this->request->request;
+        if ($this->uriPrefix) {
+            $value = $params->get($this->uriPrefix.'['.$name.']', $default, true);
+        } else {
+            $value = $params->get($name, $default);
+        }
+
+        // Use default when invalid
+        if ($validator && !call_user_func($validator, $value)) {
+            $value = $default;
+        }
+
+        return $value;
+    }
+
+    /**
+     * Checks if the processing format supported.
+     *
+     * @param string $format
+     *
+     * @throws \InvalidArgumentException when format is invalid unsupported
+     */
+    protected static function assertValidSearchFormat($format)
+    {
+        if (!is_string($format) || !in_array($format, array('json', 'xml', 'filter_query'), true)) {
+            throw new \InvalidArgumentException('Unsupported format, only accepts: json, xml or filter_query.');
+        }
+    }
+}

--- a/src/Rollerworks/Bundle/SearchBundle/Processor/CacheSearchProcessor.php
+++ b/src/Rollerworks/Bundle/SearchBundle/Processor/CacheSearchProcessor.php
@@ -1,0 +1,182 @@
+<?php
+
+/**
+ * This file is part of the RollerworksSearchBundle package.
+ *
+ * (c) 2014 Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\Processor;
+
+use Doctrine\Common\Cache\Cache;
+use Rollerworks\Component\Search\FieldSet;
+use Rollerworks\Component\Search\SearchConditionSerializer;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * CacheSearchProcessor caches processed request data
+ * for better performance.
+ *
+ * Cached data only contains only input-to-searchCondition (after formatting)
+ * and exported formats.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+class CacheSearchProcessor extends AbstractSearchProcessor
+{
+    /**
+     * @var Cache
+     */
+    private $cacheDriver;
+
+    /**
+     * @var SearchProcessorInterface
+     */
+    private $processor;
+
+    /**
+     * @var array
+     */
+    private $errors = array();
+
+    /**
+     * Constructor.
+     *
+     * @param SearchProcessorInterface $processor
+     * @param Cache                    $cacheDriver
+     * @param FieldSet                 $fieldSet
+     * @param string                   $uriPrefix
+     */
+    public function __construct(
+        SearchProcessorInterface $processor,
+        Cache $cacheDriver,
+        FieldSet $fieldSet,
+        $uriPrefix = ''
+    ) {
+        $this->processor = $processor;
+        $this->cacheDriver = $cacheDriver;
+        $this->fieldSet = $fieldSet;
+        $this->uriPrefix = $uriPrefix;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function processRequest(Request $request)
+    {
+        $this->request = $request;
+        $this->filterCode = $this->getRequestParam('filter', '');
+        $this->searchCondition = null;
+        $this->errors = array();
+
+        $isPost = 'POST' === $request->getMethod();
+        if (!$isPost && '' === $this->filterCode) {
+            return $this;
+        }
+
+        if ($isPost && $this->filterCode) {
+            $this->clearCache();
+        }
+
+        if ($isPost || !$this->loadFromCache()) {
+            if ($this->processor->processRequest($request)) {
+                $this->errors = $this->processor->getErrors();
+            } else {
+                $this->searchCondition = $this->processor->getSearchCondition();
+                $this->filterCode = $this->processor->getFilterCode();
+
+                $this->storeCache();
+            }
+        }
+
+        return $this;
+    }
+
+    public function storeCache()
+    {
+        if (!$this->searchCondition || $this->searchCondition->getValuesGroup()->hasErrors()) {
+            return;
+        }
+
+        $this->cacheDriver->save(
+            'search_condition.'.$this->fieldSet->getSetName().'.'.$this->filterCode,
+            SearchConditionSerializer::serialize($this->searchCondition)
+        );
+    }
+
+    /**
+     * Clears the cache for the current condition.
+     *
+     * @return bool
+     */
+    public function clearCache()
+    {
+        if (!$this->filterCode) {
+            return false;
+        }
+
+        $fieldSetName = $this->fieldSet->getSetName();
+        $this->cacheDriver->delete('search_condition.'.$fieldSetName.'.'.$this->filterCode);
+
+        foreach (array('json', 'xml', 'filter_query') as $format) {
+            $this->cacheDriver->delete('search_export.'.$fieldSetName.'.'.$this->filterCode.'.'.$format);
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns the exported format of the SearchCondition.
+     *
+     * @param string $format
+     *
+     * @return string|array Exported format
+     *
+     * @throws \RuntimeException When there is no SearchCondition or its invalid
+     */
+    public function exportSearchCondition($format)
+    {
+        static::assertValidSearchFormat($format);
+
+        if (null === $this->searchCondition || $this->searchCondition->getValuesGroup()->hasErrors()) {
+            throw new \RuntimeException('Unable to export empty/invalid SearchCondition');
+        }
+
+        $cacheKey = 'search_export.'.$this->filterCode.'.'.$format;
+        if ($this->cacheDriver->contains($cacheKey)) {
+            return $this->cacheDriver->fetch($cacheKey);
+        }
+
+        $exported = $this->processor->exportSearchCondition($format);
+        $this->cacheDriver->save($cacheKey, $exported);
+
+        return $exported;
+    }
+
+    /**
+     * Loads SearchCondition from the cache.
+     *
+     * @return bool
+     */
+    protected function loadFromCache()
+    {
+        $cacheKey = 'search_condition.'.$this->fieldSet->getSetName().'.'.$this->filterCode;
+        if ($this->cacheDriver->contains($cacheKey)) {
+            try {
+                $this->searchCondition = SearchConditionSerializer::unserialize(
+                    $this->fieldSet,
+                    $this->cacheDriver->fetch($cacheKey)
+                );
+
+                return true;
+            } catch (\Exception $e) {
+                $this->clearCache();
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Rollerworks/Bundle/SearchBundle/Processor/Configuration.php
+++ b/src/Rollerworks/Bundle/SearchBundle/Processor/Configuration.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of the RollerworksSearchBundle package.
+ *
+ * (c) 2014 Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\Processor;
+
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * @var int
+     */
+    private $maxValues = 10000;
+
+    /**
+     * @var int
+     */
+    private $maxGroups = 100;
+
+    /**
+     * @var int
+     */
+    private $maxNesting = 100;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSearchMaxValues()
+    {
+        return $this->maxValues;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSearchMaxGroups()
+    {
+        return $this->maxGroups;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSearchMaxNesting()
+    {
+        return $this->maxNesting;
+    }
+}

--- a/src/Rollerworks/Bundle/SearchBundle/Processor/ConfigurationInterface.php
+++ b/src/Rollerworks/Bundle/SearchBundle/Processor/ConfigurationInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of the RollerworksSearchBundle package.
+ *
+ * (c) 2014 Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\Processor;
+
+interface ConfigurationInterface
+{
+    /**
+     * @return int
+     */
+    public function getSearchMaxValues();
+
+    /**
+     * @return int
+     */
+    public function getSearchMaxGroups();
+
+    /**
+     * @return int
+     */
+    public function getSearchMaxNesting();
+}

--- a/src/Rollerworks/Bundle/SearchBundle/Processor/SearchProcessor.php
+++ b/src/Rollerworks/Bundle/SearchBundle/Processor/SearchProcessor.php
@@ -1,0 +1,210 @@
+<?php
+
+/**
+ * This file is part of the RollerworksSearchBundle package.
+ *
+ * (c) 2014 Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\Processor;
+
+use Rollerworks\Bundle\SearchBundle\ExceptionParser;
+use Rollerworks\Component\ExceptionParser\ExceptionParserManager;
+use Rollerworks\Component\Search\Extension\Symfony\DependencyInjection\ExporterFactory;
+use Rollerworks\Component\Search\Extension\Symfony\DependencyInjection\InputFactory;
+use Rollerworks\Component\Search\FieldSet;
+use Rollerworks\Component\Search\FormatterInterface;
+use Rollerworks\Component\Search\Input\AbstractInput;
+use Rollerworks\Component\UriEncoder\UriEncoderInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * SearchProcessorInterface processes search-data.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+class SearchProcessor extends AbstractSearchProcessor
+{
+    /**
+     * @var ConfigurationInterface
+     */
+    protected $config;
+
+    /**
+     * @var InputFactory
+     */
+    protected $inputFactory;
+
+    /**
+     * @var ExporterFactory
+     */
+    protected $exportFactory;
+
+    /**
+     * @var FormatterInterface
+     */
+    protected $formatter;
+
+    /**
+     * @var UriEncoderInterface
+     */
+    protected $uriEncoder;
+
+    /**
+     * Constructor.
+     *
+     * @param InputFactory           $inputFactory
+     * @param ExporterFactory        $exportFactory
+     * @param FormatterInterface     $formatter
+     * @param UriEncoderInterface    $uirEncoder
+     * @param ConfigurationInterface $config        ControllerResourceConfig
+     * @param FieldSet               $fieldSet      FieldSet instance for filtering
+     * @param string                 $uriPrefix     URI-prefix, used when there are multiple filters on a page
+     */
+    public function __construct(
+        InputFactory $inputFactory,
+        ExporterFactory $exportFactory,
+        FormatterInterface $formatter,
+        UriEncoderInterface $uirEncoder,
+        ConfigurationInterface $config,
+        FieldSet $fieldSet,
+        $uriPrefix = ''
+    ) {
+        $this->inputFactory = $inputFactory;
+        $this->exportFactory = $exportFactory;
+        $this->formatter = $formatter;
+        $this->uriEncoder = $uirEncoder;
+
+        $this->config = $config;
+        $this->fieldSet = $fieldSet;
+        $this->uriPrefix = (string) $uriPrefix;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function processRequest(Request $request)
+    {
+        $this->request = $request;
+        $isPost = $request->isMethod('POST');
+
+        $input = $this->getRequestParam('filter', '', !$isPost);
+        $format = $this->getRequestParam('format', 'filter_query', !$isPost);
+
+        if ('' === $input) {
+            $this->searchCondition = null;
+            $this->filterCode = '';
+            $this->errors = array();
+
+            return $this;
+        }
+
+        if (!$isPost) {
+            $input = $this->uriEncoder->decodeUri($input);
+        }
+
+        static::assertValidSearchFormat($format);
+        $this->processInput($input, $format);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function exportSearchCondition($format)
+    {
+        static::assertValidSearchFormat($format);
+
+        if (null === $this->searchCondition || $this->searchCondition->getValuesGroup()->hasErrors()) {
+            throw new \RuntimeException('Unable to export empty/invalid SearchCondition');
+        }
+
+        $export = $this->exportFactory->create($format);
+
+        return $export->exportCondition($this->searchCondition, 'filter_query' === $format);
+    }
+
+    /**
+     * Processes the input to a SearchCondition.
+     *
+     * @param string $input
+     * @param string $format
+     */
+    protected function processInput($input, $format)
+    {
+        if ('' === $input) {
+            return;
+        }
+
+        $this->filterCode = '';
+
+        try {
+            $this->searchCondition = $this->getInputProcessor($this->fieldSet, $format)->process($input);
+        } catch (\Exception $e) {
+            $this->errors = array($this->getExceptionMessage($e));
+            $this->searchCondition = null;
+
+            return;
+        }
+
+        $this->formatter->format($this->searchCondition);
+
+        if (!$this->searchCondition->getValuesGroup()->hasErrors()) {
+            $this->filterCode = $this->uriEncoder->encodeUri($this->exportSearchCondition('filter_query'));
+        }
+    }
+
+    /**
+     * Transforms the Exception to a Message object.
+     *
+     * @param \Exception $exception
+     *
+     * @return array
+     *
+     * @throws \Exception When exception can not be parsed
+     */
+    protected function getExceptionMessage(\Exception $exception)
+    {
+        $exceptionParser = new ExceptionParserManager('{{ {var} }}');
+        $exceptionParser->addExceptionParser(new ExceptionParser\QueryExceptionParser());
+        $exceptionParser->addExceptionParser(new ExceptionParser\SearchFieldRequiredExceptionParser());
+        $exceptionParser->addExceptionParser(new ExceptionParser\SearchGroupsOverflowExceptionParser());
+        $exceptionParser->addExceptionParser(new ExceptionParser\SearchValuesOverflowExceptionParser());
+        $exceptionParser->addExceptionParser(new ExceptionParser\SearchGroupsNestingExceptionParser());
+        $exceptionParser->addExceptionParser(new ExceptionParser\SearchUnsupportedValueTypeExceptionParser());
+        $exceptionParser->addExceptionParser(new ExceptionParser\SearchUnknownFieldExceptionParser());
+
+        $params = $exceptionParser->processException($exception);
+
+        // No compatible parser re-throw for external caching
+        if (array() === $params) {
+            throw $exception;
+        }
+
+        return $params;
+    }
+
+    /**
+     * Gets a new InputProcessor for the given format.
+     *
+     * @param FieldSet $fieldset
+     * @param string   $inputFormat
+     *
+     * @return AbstractInput
+     */
+    protected function getInputProcessor(FieldSet $fieldset, $inputFormat)
+    {
+        /** @var AbstractInput $inputProcessor */
+        $inputProcessor = $this->inputFactory->create($inputFormat);
+        $inputProcessor->setFieldSet($fieldset);
+        $inputProcessor->setMaxValues($this->config->getSearchMaxValues());
+        $inputProcessor->setMaxGroups($this->config->getSearchMaxGroups());
+        $inputProcessor->setMaxNestingLevel($this->config->getSearchMaxNesting());
+
+        return $inputProcessor;
+    }
+}

--- a/src/Rollerworks/Bundle/SearchBundle/Processor/SearchProcessorFactory.php
+++ b/src/Rollerworks/Bundle/SearchBundle/Processor/SearchProcessorFactory.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * This file is part of the RollerworksSearchBundle package.
+ *
+ * (c) 2014 Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\Processor;
+
+use Doctrine\Common\Cache\Cache;
+use Rollerworks\Component\Search\Extension\Symfony\DependencyInjection\ExporterFactory;
+use Rollerworks\Component\Search\Extension\Symfony\DependencyInjection\FieldSetRegistry;
+use Rollerworks\Component\Search\Extension\Symfony\DependencyInjection\InputFactory;
+use Rollerworks\Component\Search\FieldSet;
+use Rollerworks\Component\Search\FormatterInterface;
+use Rollerworks\Component\UriEncoder\UriEncoderInterface;
+
+/**
+ * SearchProcessorFactory creates a new SearchProcessor
+ * or CacheSearchProcessor for usage.
+ */
+class SearchProcessorFactory implements SearchProcessorFactoryInterface
+{
+    /**
+     * @var InputFactory
+     */
+    private $inputFactory;
+
+    /**
+     * @var ExporterFactory
+     */
+    private $exporterFactory;
+
+    /**
+     * @var FieldSetRegistry
+     */
+    private $fieldSetRegistry;
+
+    /**
+     * @var UriEncoderInterface
+     */
+    private $uriEncoder;
+
+    /**
+     * @var FormatterInterface
+     */
+    private $formatter;
+
+    /**
+     * @var Cache
+     */
+    private $cacheAdapter;
+
+    /**
+     * Constructor.
+     *
+     * @param InputFactory        $inputFactory
+     * @param ExporterFactory     $exporterFactory
+     * @param FormatterInterface  $formatter
+     * @param FieldSetRegistry    $fieldSetRegistry
+     * @param UriEncoderInterface $uriEncoder
+     * @param Cache               $cacheAdapter
+     */
+    public function __construct(
+        InputFactory $inputFactory,
+        ExporterFactory $exporterFactory,
+        FormatterInterface $formatter,
+        FieldSetRegistry $fieldSetRegistry,
+        UriEncoderInterface $uriEncoder,
+        Cache $cacheAdapter
+    ) {
+        $this->inputFactory = $inputFactory;
+        $this->exporterFactory = $exporterFactory;
+        $this->fieldSetRegistry = $fieldSetRegistry;
+        $this->uriEncoder = $uriEncoder;
+        $this->formatter = $formatter;
+        $this->cacheAdapter = $cacheAdapter;
+    }
+
+    /**
+     * Creates a new SearchProcessor instance.
+     *
+     * @param string|FieldSet        $fieldSet  FieldSet object or FieldSet name
+     * @param ConfigurationInterface $config    Search Configuration object
+     * @param string                 $uriPrefix URL prefix to allow multiple processors per page
+     * @param bool                   $cached    Use cached processor (recommended paged results)
+     *
+     * @return SearchProcessor|CacheSearchProcessor
+     */
+    public function createProcessor($fieldSet, ConfigurationInterface $config, $uriPrefix = '', $cached = true)
+    {
+        if (!$fieldSet instanceof FieldSet) {
+            $fieldSet = $this->fieldSetRegistry->getFieldSet($fieldSet);
+        }
+
+        $processor = new SearchProcessor(
+            $this->inputFactory,
+            $this->exporterFactory,
+            $this->formatter,
+            $this->uriEncoder,
+            $config,
+            $fieldSet,
+            $uriPrefix
+        );
+
+        if ($cached) {
+            $processor = new CacheSearchProcessor($processor, $this->cacheAdapter, $fieldSet, $uriPrefix);
+        }
+
+        return $processor;
+    }
+}

--- a/src/Rollerworks/Bundle/SearchBundle/Processor/SearchProcessorFactoryInterface.php
+++ b/src/Rollerworks/Bundle/SearchBundle/Processor/SearchProcessorFactoryInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of the RollerworksSearchBundle package.
+ *
+ * (c) 2014 Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\Processor;
+
+use Rollerworks\Bundle\SearchBundle\DependencyInjection\Factory\FieldSet;
+
+interface SearchProcessorFactoryInterface
+{
+    /**
+     * Creates a new SearchProcessorInterface object instance.
+     *
+     * @param string|FieldSet        $fieldSet  FieldSet object or FieldSet name
+     * @param ConfigurationInterface $config    Search Configuration object
+     * @param string                 $uriPrefix URL prefix to allow multiple processors per page
+     *
+     * @return SearchProcessorInterface
+     */
+    public function createProcessor($fieldSet, ConfigurationInterface $config, $uriPrefix = '');
+}

--- a/src/Rollerworks/Bundle/SearchBundle/Processor/SearchProcessorInterface.php
+++ b/src/Rollerworks/Bundle/SearchBundle/Processor/SearchProcessorInterface.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * This file is part of the RollerworksSearchBundle package.
+ *
+ * (c) 2014 Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\Processor;
+
+use Rollerworks\Component\Search\SearchConditionInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * SearchProcessorInterface.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+interface SearchProcessorInterface
+{
+    /**
+     * Processes the search data from the request.
+     *
+     * Returns false when there are violations, errors, or when there is no new filtering.
+     * You should call isValid() to determine of the result is valid.
+     *
+     * @param Request $request
+     *
+     * @return self
+     */
+    public function processRequest(Request $request);
+
+    /**
+     * Gets the unique filtering-code.
+     *
+     * @return string
+     */
+    public function getFilterCode();
+
+    /**
+     * Gets the SearchCondition.
+     *
+     * @return SearchConditionInterface|null
+     */
+    public function getSearchCondition();
+
+    /**
+     * Gets the exported format of the SearchCondition.
+     *
+     * @param string $format
+     *
+     * @return string|array Exported format
+     *
+     * @throws \RuntimeException When there is no SearchCondition or its invalid
+     */
+    public function exportSearchCondition($format);
+
+    /**
+     * Gets processing error.
+     *
+     * @return array[]|\Traversable
+     */
+    public function getErrors();
+
+    /**
+     * Returns whether the processed result is valid.
+     *
+     * @return bool
+     */
+    public function isValid();
+}

--- a/src/Rollerworks/Bundle/SearchBundle/SearchFilterStorage/SessionStorage.php
+++ b/src/Rollerworks/Bundle/SearchBundle/SearchFilterStorage/SessionStorage.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This file is part of the RollerworksSearchBundle package.
+ *
+ * (c) 2014 Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle\SearchFilterStorage;
+
+use Rollerworks\Bundle\SearchBundle\SearchFilterStorageInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+/**
+ * SessionStorage stores search filter-codes using the Symfony Session
+ * system.
+ */
+class SessionStorage implements SearchFilterStorageInterface
+{
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * Constructor.
+     *
+     * @param SessionInterface $session
+     */
+    public function __construct(SessionInterface $session)
+    {
+        $this->session = $session;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function containsFilter($filterName)
+    {
+        return $this->session->has('rollerworks_search.filter_code'.$filterName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilterCode($filterName)
+    {
+        return $this->session->get('rollerworks_search.filter_code'.$filterName, '');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setFilterCode($filterName, $filterCode)
+    {
+        $this->session->set('rollerworks_search.filter_code'.$filterName, $filterCode);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeFilter($filterName)
+    {
+        $this->session->remove('rollerworks_search.filter_code'.$filterName);
+    }
+}

--- a/src/Rollerworks/Bundle/SearchBundle/SearchFilterStorageInterface.php
+++ b/src/Rollerworks/Bundle/SearchBundle/SearchFilterStorageInterface.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This file is part of the RollerworksSearchBundle package.
+ *
+ * (c) 2014 Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\SearchBundle;
+
+/**
+ * SearchFilterStorageInterface for storing search-filters
+ * for persistent usage.
+ *
+ * A storage can be anything from a cookie, PHP session or
+ * entry in a database.
+ *
+ * @package Rollerworks\Bundle\SearchBundle
+ */
+interface SearchFilterStorageInterface
+{
+    /**
+     * Returns whether the storage contains the filter.
+     *
+     * @param string $filterName Name of the filter (eg. FieldSet name)
+     *
+     * @return bool
+     */
+    public function containsFilter($filterName);
+
+    /**
+     * Returns the filter-code from the storage.
+     *
+     * @param string $filterName Name of the filter (eg. FieldSet name)
+     *
+     * @return string
+     */
+    public function getFilterCode($filterName);
+
+    /**
+     * Sets the filter-code by filter-name.
+     *
+     * @param string $filterName Name of the filter (eg. FieldSet name)
+     * @param string $filterCode Filtering code (encoded structure)
+     */
+    public function setFilterCode($filterName, $filterCode);
+
+    /**
+     * Removes the filter-code from the storage.
+     *
+     * @param string $filterName Name of the filter (eg. FieldSet name)
+     */
+    public function removeFilter($filterName);
+}


### PR DESCRIPTION
                   
|Q            |A  |
|---          |---|
|Bug Fix?     |no |
|New Feature? |yes|
|BC Breaks?   |no |
|Deprecations?|no |
|Tests Pass?  |no |
|Fixed Tickets|   |
|License      |MIT|
                   

Basically it provides a way to make searching easier.

* Translating input-processor errors to human friendly version
* Processing a search-form and processing from the request
* Caching processed results for better performance

And provides an optional system to remember the search-condition
using a filter-code which may be stored in a session or cookie
(or anything else)

Tests and documentation are currently missing.
This just a RFC idea to get something working.

Even though its not really coupled to the FrameworkBundle
most logic it not really usable for other Frameworks at the moment.

 Sent using [Gush](https://github.com/gushphp/gush)