### PR TITLE
Make SearchProcessor test separate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,11 @@ matrix:
         - php: '7.1'
           env: deps='low'
         - php: '7.1'
-          env: doctrine='dbal'
+          env: testcase='doctrine_dbal'
         - php: '7.1'
-          env: doctrine='orm'
+          env: testcase='doctrine_orm'
+        - php: '7.1'
+          env: testcase='search_processor'
 env:
     global:
         - TMPDIR=/tmp
@@ -28,15 +30,21 @@ before_install:
     - phpenv config-rm xdebug.ini || echo "xdebug not available"
     - export PATH="$PATH:$HOME/.composer/vendor/bin"
     - |
-        if [[ $doctrine = 'dbal' ]]; then
+        if [[ $testcase = 'doctrine_dbal' ]]; then
             composer require --no-update "doctrine/doctrine-bundle:^1.1"
             composer require --no-update "rollerworks/search-doctrine-dbal:^2.0@dev"
         fi;
 
-        if [[ $doctrine = 'orm' ]]; then
+        if [[ $testcase = 'doctrine_orm' ]]; then
             composer require --no-update "doctrine/doctrine-bundle:^1.1"
             composer require --no-update "rollerworks/search-doctrine-orm:^2.0@dev"
-        fi
+        fi;
+
+        if [[ $testcase = 'search_processor' ]]; then
+            composer require --no-update "rollerworks/search-processor:^1.0@dev"
+            composer require --no-update "symfony/psr-http-message-bridge:^1.0.0"
+            composer require --no-update "zendframework/zend-diactoros:^1.3.9"
+        fi;
 
 install:
     - export SYMFONY_PHPUNIT_REMOVE="symfony/yaml"

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,11 @@
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^1.1.0",
         "matthiasnoback/symfony-service-definition-validator": "^1.2.7",
-        "rollerworks/search-processor": "^1.0@dev",
         "rollerworks/search-symfony-validator": "^2.0@dev",
         "symfony/browser-kit": "^3.2.4",
         "symfony/routing": "^3.2.4",
         "symfony/dom-crawler": "^3.2.4",
-        "symfony/phpunit-bridge": "^3.2.4",
-        "symfony/psr-http-message-bridge": "^1.0.0",
-        "zendframework/zend-diactoros": "^1.3.9"
+        "symfony/phpunit-bridge": "^3.2.4"
     },
     "conflict": {
         "symfony/psr-http-message-bridge": "<1.0.0",

--- a/tests/Functional/SearchProcessorTest.php
+++ b/tests/Functional/SearchProcessorTest.php
@@ -13,8 +13,17 @@ declare(strict_types=1);
 
 namespace Rollerworks\Bundle\SearchBundle\Tests\Functional;
 
+use Rollerworks\Component\Search\Processor\Psr7SearchProcessor;
+
 final class SearchProcessorTest extends FunctionalTestCase
 {
+    public static function setUpBeforeClass()
+    {
+        if (!class_exists(Psr7SearchProcessor::class)) {
+            self::markTestSkipped('rollerworks/search-processor is not installed.');
+        }
+    }
+
     public function testEmptySearchCodeIsValid()
     {
         $client = self::newClient();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

Ensure the SearchProcessor is automatically enabled and the bundle works when the package is not installed.