### PR TITLE
Change SearchProcessor default cache to array

### DIFF
--- a/src/DependencyInjection/RollerworksSearchExtension.php
+++ b/src/DependencyInjection/RollerworksSearchExtension.php
@@ -77,7 +77,7 @@ class RollerworksSearchExtension extends Extension implements PrependExtensionIn
                 'cache' => [
                     'pools' => [
                         'rollerworks.search_processor.cache' => [
-                            'adapter' => 'cache.system',
+                            'adapter' => 'rollerworks_search.cache.adapter.array',
                         ],
                     ],
                 ],

--- a/src/Resources/config/search_processor.xml
+++ b/src/Resources/config/search_processor.xml
@@ -38,5 +38,16 @@
 
         <service id="Rollerworks\Component\Search\Processor\SearchProcessor" alias="rollerworks_search.search_processor" />
         <service id="rollerworks_search.search_processor" alias="rollerworks_search.http_foundation_search_processor" public="true" />
+
+        <service id="rollerworks_search.cache.adapter.array" class="Symfony\Component\Cache\Adapter\ArrayAdapter" abstract="true">
+            <tag name="cache.pool" clearer="cache.default_clearer" />
+            <tag name="monolog.logger" channel="cache" />
+            <argument /> <!-- namespace -->
+            <argument>0</argument> <!-- default lifetime -->
+            <argument /> <!-- version -->
+            <call method="setLogger">
+                <argument type="service" id="logger" on-invalid="ignore" />
+            </call>
+        </service>
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

The default was cache.system which uses the Filesystem, and is not suitable
for performance
